### PR TITLE
Switch from Next.js to Vite

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,29 +1,35 @@
 {
   "name": "web",
-  "version": "0.0.1",
   "private": true,
+  "version": "0.0.1",
+  "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "clean": "rm -rf .next node_modules"
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "shared": "*",
-    "@supabase/auth-helpers-nextjs": "^0.8.7",
     "@supabase/supabase-js": "^2.39.1",
-    "next": "14.0.4",
-    "react": "^18",
-    "react-dom": "^18"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1"
   },
   "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
+    "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.0.1",
-    "postcss": "^8",
-    "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "eslint": "^8.55.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.6",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.8"
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,29 @@
+import { Routes, Route } from 'react-router-dom'
+import { formatCurrency, formatDate } from 'shared/utils'
+
+function App() {
+  const amount = 1234.56
+  const today = new Date()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main className="container mx-auto px-4 py-8">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold">Darpo - Hotel Management</h1>
+          
+          <div className="p-4 bg-white rounded-lg shadow">
+            <h2 className="text-xl font-semibold">Testing Shared Utils</h2>
+            <p>Formatted Currency: {formatCurrency(amount)}</p>
+            <p>Formatted Date: {formatDate(today)}</p>
+          </div>
+        </div>
+
+        <Routes>
+          {/* Add routes here */}
+        </Routes>
+      </main>
+    </div>
+  )
+}
+
+export default App

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Darpo - Hotel Management</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src')
+    }
+  }
+})


### PR DESCRIPTION
## Changes
- Remove Next.js dependencies and configuration
- Add Vite setup with React
- Configure TypeScript and TailwindCSS
- Setup React Router for navigation
- Keep shared package integration
- Update development scripts

## Why
Since we're using Supabase as our backend:
1. We don't need Next.js server features
2. API routes are handled by Supabase
3. Simpler development setup with Vite
4. Faster hot reload during development
5. Smaller bundle size

## Testing
1. Clean install dependencies:
```bash
npm clean-install
```

2. Start development server:
```bash
npm run dev
```

3. Verify:
- Shared utils still work
- TailwindCSS styles apply
- Hot reload functions
- TypeScript types are correct

## Next Steps
1. Add authentication setup
2. Create dashboard layout
3. Implement main features