### PR TITLE
feat: Add login and protected dashboard routes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,39 +1,8 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import { Button } from './components/ui/button'
+import { RouterProvider } from 'react-router-dom';
+import { router } from './routes';
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-
-      <Button> Hello mamaji ...</Button>
-
-    </>
-  )
+  return <RouterProvider router={router} />;
 }
 
-export default App
+export default App;

--- a/apps/web/src/features/auth/routes/Login.tsx
+++ b/apps/web/src/features/auth/routes/Login.tsx
@@ -1,0 +1,22 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { GoogleSignIn } from '../components/GoogleSignIn';
+
+export function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl font-bold">Welcome to Darpo</CardTitle>
+          <CardDescription>
+            Hotel Management System
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <GoogleSignIn />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/routes/Dashboard.tsx
+++ b/apps/web/src/features/dashboard/routes/Dashboard.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+
+export function DashboardPage() {
+  const { user, signOut } = useAuth();
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">Dashboard</h1>
+        <button
+          onClick={signOut}
+          className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700"
+        >
+          Sign Out
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Organizations</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">0</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Properties</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">0</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Users</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">0</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,0 +1,19 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { LoginPage } from '@/features/auth/routes/Login';
+import { DashboardPage } from '@/features/dashboard/routes/Dashboard';
+import { AuthGuard } from '@/features/auth/components/AuthGuard';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <LoginPage />
+  },
+  {
+    path: '/dashboard',
+    element: (
+      <AuthGuard>
+        <DashboardPage />
+      </AuthGuard>
+    )
+  }
+]);


### PR DESCRIPTION
This PR adds the login page and protected dashboard route with the following features:

### Changes
1. Login Page (`/`)
   - Clean, centered design
   - Google Sign-in integration
   - Responsive layout

2. Dashboard Page (`/dashboard`)
   - Protected route using AuthGuard
   - Basic stats cards layout
   - Sign out functionality
   - Responsive grid layout

3. Router Setup
   - Added React Router configuration
   - Protected route handling
   - Base route structure

### Testing
1. Access `/` - should show login page
2. Click Google Sign-in
3. After auth, should redirect to `/dashboard`
4. Try accessing `/dashboard` directly:
   - If not logged in: redirects to login
   - If logged in: shows dashboard

### Screenshots
- Login Page:
  ![Login Page Screenshot]
- Dashboard:
  ![Dashboard Screenshot]

### Dependencies Required
- react-router-dom
- shadcn/ui components