### PR TITLE
fix: Resolve BSON dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "supabase": "~2.6.8",
+    "supabase": "^2.39.0",
     "prettier": "^3.1.1",
     "turbo": "^1.11.3"
   },
   "engines": {
     "node": ">=18.0.0"
   },
-  "packageManager": "npm@10.2.3"
+  "packageManager": "npm@10.2.3",
+  "resolutions": {
+    "bson": "^6.2.0"
+  }
 }


### PR DESCRIPTION
This PR fixes the BSON dependency error by:

1. Adding resolutions in root package.json
2. Updating Supabase version

Steps to test:
1. Delete all node_modules folders:
```bash
rm -rf node_modules
rm -rf apps/*/node_modules
rm -rf packages/*/node_modules
```

2. Clean install:
```bash
npm install
```

3. Run the app:
```bash
npm run dev
```

The BSON error should be resolved.