### PR TITLE
fix: Add React Query provider setup

### DIFF
--- a/apps/web/src/lib/react-query.tsx
+++ b/apps/web/src/lib/react-query.tsx
@@ -1,0 +1,18 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000, // 1 minute
+      retry: 1,
+    },
+  },
+});
+
+export function ReactQueryProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { ReactQueryProvider } from './lib/react-query';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ReactQueryProvider>
+      <App />
+    </ReactQueryProvider>
+  </React.StrictMode>
+);


### PR DESCRIPTION
This PR fixes the React Query setup error by:

1. Adding proper React Query Provider
2. Setting up QueryClient with default options
3. Wrapping the app with QueryClientProvider

### Changes
- Created `ReactQueryProvider` component
- Added QueryClient configuration
- Updated main.tsx to include the provider

### Testing
1. Start the app
2. Verify no React Query errors in console
3. Test authentication flow (uses React Query)

### Default Query Options
- Stale Time: 1 minute
- Retry attempts: 1

These settings can be adjusted based on requirements.